### PR TITLE
Add rules for module imports

### DIFF
--- a/default.js
+++ b/default.js
@@ -10,5 +10,6 @@ module.exports = {
         'eslint-config-nutshell/rules/react',
         'eslint-config-nutshell/rules/strict',
         'eslint-config-nutshell/rules/style',
+        'eslint-config-nutshell/rules/import',
     ],
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "peerDependencies": {
     "eslint": "^1.6.0",
     "eslint-plugin-babel": "^2.1.1",
-    "eslint-plugin-react": "^3.8.0"
+    "eslint-plugin-react": "^3.8.0",
+    "eslint-config-import": "^0.9.1",
+    "eslint-plugin-import": "^0.10.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.4",

--- a/rules/import.js
+++ b/rules/import.js
@@ -12,6 +12,8 @@ module.exports = {
         'import/no-unresolved'      : [2],
         // Ensure named imports correspond to a named export in the remote file
         'import/named'              : [2],
+        // Ensure imported namespaces contain dereferenced properties as they are dereferenced
+        'import/namespace'          : [2],
         // Ensure a default export is present, given a default import
         'import/default'            : [2],
         // Report use of exported name as identifier of default export

--- a/rules/import.js
+++ b/rules/import.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+    'extends': [
+        'import/es7-jsx',
+    ],
+    'plugins': [
+        'import',
+    ],
+    'rules': {
+        // Ensure imports point to a file/module that can be resolved
+        'import/no-unresolved'      : [2],
+        // Ensure named imports correspond to a named export in the remote file
+        'import/named'              : [2],
+        // Ensure a default export is present, given a default import
+        'import/default'            : [2],
+        // Report use of exported name as identifier of default export
+        'import/no-named-as-default': [2],
+    },
+};

--- a/rules/import.js
+++ b/rules/import.js
@@ -17,4 +17,9 @@ module.exports = {
         // Report use of exported name as identifier of default export
         'import/no-named-as-default': [2],
     },
+    'settings': {
+        'import/resolve': {
+            'extensions': ['.js', '.jsx'],
+        },
+    },
 };


### PR DESCRIPTION
This adds some rules for ES6 imports, ensuring that we are only importing files which can resolve, named exports actually exist, etc.

This will require a bump to `2.0.0`, as it will currently break linting on nutshell.

cc @andrewsardone 