### PR TITLE
Add implicit coercion check

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   "devDependencies": {
     "babel-eslint": "^4.1.4",
     "eslint": ">=1.6.0",
+    "eslint-config-import": "^0.9.1",
     "eslint-plugin-babel": "^2.1.1",
+    "eslint-plugin-import": "^0.10.0",
     "eslint-plugin-react": "^3.8.0"
   }
 }

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -3,14 +3,16 @@
 module.exports = {
     'rules': {
         // Specify curly brace conventions for all control statements
-        'curly'            : [2, 'multi-line'],
+        'curly'               : [2, 'multi-line'],
+        // Disallow the type conversions with shorter notations
+        'no-implicit-coercion': [2],
         // Disallow use of multiple spaces
-        'no-multi-spaces'  : [2],
+        'no-multi-spaces'     : [2],
         // Disallow reassignment of function parameters
-        'no-param-reassign': [2],
+        'no-param-reassign'   : [2],
         // Disallow comparisons where both sides are exactly the same
-        'no-self-compare'  : [2],
+        'no-self-compare'     : [2],
         // Disallow usage of expressions in statement position
-        'no-throw-literal' : [2],
+        'no-throw-literal'    : [2],
     },
 };


### PR DESCRIPTION
This adds a check to prevent shot form of type conversions, which can be expressed more explicitly.  See http://eslint.org/docs/rules/no-implicit-coercion for rule details.

It will currently not cause failures on nutshell or nutshell-ios.

cc @andrewsardone
