### PR TITLE
Fix npm installation error, EPEERINVALID, around peerDependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "homepage": "https://github.com/nutshellcrm/eslint-config-nutshell#readme",
   "peerDependencies": {
-    "eslint": "^1.6.0",
-    "eslint-plugin-babel": "^2.1.1",
-    "eslint-plugin-react": "^3.8.0",
-    "eslint-config-import": "^0.9.1",
-    "eslint-plugin-import": "^0.10.0"
+    "eslint": ">=1.6.0",
+    "eslint-plugin-babel": ">=2.1.1",
+    "eslint-plugin-react": ">=3.8.0",
+    "eslint-config-import": ">=0.9.1",
+    "eslint-plugin-import": ">=0.10.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.4",


### PR DESCRIPTION

Currently when installing with npm2, you'll see the following `peerDependencies` warnings:

```
npm WARN peerDependencies The peer dependency eslint-plugin-babel@^2.1.1 included from eslint-config-nutshell will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm WARN peerDependencies The peer dependency eslint-plugin-import@^0.10.0 included from eslint-config-nutshell will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```

…and with [the release of eslint-plugin-babel v3.0.0][r], it appears installation actually _fails_ as npm seemingly ignores our peer dependency version requirement:

```
npm ERR! Darwin 15.0.0
npm ERR! argv "node" "npm" "install" "--save-dev" "eslint" "eslint-config-nutshell"
npm ERR! node v4.0.0
npm ERR! npm  v2.14.2
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package eslint-plugin-babel@3.0.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-nutshell@2.0.0 wants eslint-plugin-babel@^2.1.1
```

---

Either there's a fix that's more fundamental that needs to be addressed (which can be changed within this PR), or the README should follow the warnings’ tip and note an _explicit_ version dependency.

[r]: https://github.com/babel/eslint-plugin-babel/releases/tag/v3.0.0

---

_2015-11-29 update_: Force pushed to the PR to remove README tweaks in favor of loosening peerDependencies.