### PR TITLE
Prevent trailing spaces

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -52,5 +52,7 @@ module.exports = {
         'space-return-throw-case'    : [2],
         // Disallow spaces before/after unary operators
         'space-unary-ops'            : [2],
+        // Disallow spaces at the ends of lines
+        'no-trailing-spaces'         : [2],
     },
 };


### PR DESCRIPTION
Most editors can strip these out anyway, but it's best to make sure they aren't accidentally committed.