### PR TITLE
Update linting config for 2018

### DIFF
--- a/default.js
+++ b/default.js
@@ -10,6 +10,7 @@ module.exports = {
         'eslint-config-nutshell/rules/best-practices',
         'eslint-config-nutshell/rules/errors',
         'eslint-config-nutshell/rules/es6',
+        'eslint-config-nutshell/rules/eslint-comments',
         'eslint-config-nutshell/rules/flowtype',
         'eslint-config-nutshell/rules/react',
         'eslint-config-nutshell/rules/strict',

--- a/default.js
+++ b/default.js
@@ -10,6 +10,7 @@ module.exports = {
         'eslint-config-nutshell/rules/best-practices',
         'eslint-config-nutshell/rules/errors',
         'eslint-config-nutshell/rules/es6',
+        'eslint-config-nutshell/rules/flowtype',
         'eslint-config-nutshell/rules/react',
         'eslint-config-nutshell/rules/strict',
         'eslint-config-nutshell/rules/style',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-babel": "3.x - 4.x",
     "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.0.0",
-    "eslint-plugin-react": "^7.0.0"
+    "eslint-plugin-react": "^7.5.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-flowtype": "^2.42.0",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint-plugin-react": "^7.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "peerDependencies": {
     "eslint": "^4.0.0",
     "eslint-plugin-babel": "3.x - 4.x",
+    "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-react": "^7.0.0"
   },
@@ -37,6 +38,7 @@
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-react": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "peerDependencies": {
     "eslint": "^4.7.0",
     "eslint-plugin-babel": "^4.1.0",
+    "eslint-plugin-eslint-comments": "^2.0.0",
     "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-react": "^7.5.0"
@@ -37,8 +38,9 @@
     "eslint-config-nutshell": "file:.",
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-babel": "^4.1.2",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-eslint-comments": "^2.0.2",
     "eslint-plugin-flowtype": "^2.42.0",
+    "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/nutshellcrm/eslint-config-nutshell#readme",
   "peerDependencies": {
     "eslint": "^4.0.0",
-    "eslint-plugin-babel": "3.x - 4.x",
+    "eslint-plugin-babel": "^4.1.0",
     "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-react": "^7.5.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/nutshellcrm/eslint-config-nutshell#readme",
   "peerDependencies": {
-    "eslint": "^4.0.0",
+    "eslint": "^4.7.0",
     "eslint-plugin-babel": "^4.1.0",
     "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.0.0",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
-    "eslint": "^4.3.0",
+    "eslint": "^4.7.0",
     "eslint-config-nutshell": "file:.",
     "eslint-find-rules": "^3.1.1",
     "eslint-plugin-babel": "^4.1.2",

--- a/rules/babel.js
+++ b/rules/babel.js
@@ -5,5 +5,7 @@ module.exports = {
     'rules'  : {
         // Use babel/new-cap instead of new-cap for decorator support
         'babel/new-cap': [2],
+        // Enforce semicolons at the end of class properties
+        'babel/semi'   : [2],
     },
 };

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,8 +4,6 @@ module.exports = {
     'rules': {
         // Enforce return statements in callbacks of array methods
         'array-callback-return'       : [2],
-        // Enforce that class methods utilize this
-        'class-methods-use-this'      : [2],
         // Specify curly brace conventions for all control statements
         'curly'                       : [2, 'multi-line'],
         // Require dot Nntation
@@ -33,7 +31,7 @@ module.exports = {
         // Disallow Functions in Loops
         'no-loop-func'                : [2],
         // Disallow use of multiple spaces
-        'no-multi-spaces'             : [2],
+        'no-multi-spaces'             : [2, {'ignoreEOLComments': true}],
         // Disallow new operators with the Function object
         'no-new-func'                 : [2],
         // Disallow new operators with the String, Number, and Boolean objects
@@ -56,5 +54,7 @@ module.exports = {
         'no-useless-escape'           : [2],
         // Disallow redundant return statements
         'no-useless-return'           : [2],
+        // --- Disabled Rules ---
+        'class-methods-use-this'      : [0],
     },
 };

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -2,8 +2,6 @@
 
 module.exports = {
     'rules': {
-        // Require parentheses around arrow function arguments as-needed
-        'arrow-parens'           : [2, 'as-needed'],
         // Require space before/after arrow function’s arrow
         'arrow-spacing'          : [2],
         // Disallow use of this/super before calling super() in constructors
@@ -14,8 +12,6 @@ module.exports = {
         'no-useless-constructor' : [2],
         // Require let or const instead of var
         'no-var'                 : [2],
-        // Require arrow functions as callbacks
-        'prefer-arrow-callback'  : [2],
         // Require const declarations for variables that are never reassigned after declared
         'prefer-const'           : [2],
         // Require spread operators instead of .apply()
@@ -28,5 +24,8 @@ module.exports = {
         'rest-spread-spacing'    : [2, 'never'],
         // Disallow spacing around embedded expressions of template strings
         'template-curly-spacing' : [2, 'never'],
+        // --- Disabled Rules ---
+        'arrow-parens'           : [0],
+        'prefer-arrow-callback'  : [0],
     },
 };

--- a/rules/eslint-comments.js
+++ b/rules/eslint-comments.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+    'plugins': [
+        'eslint-comments',
+    ],
+    'rules': {
+        // Disallow eslint-disable comments without rule names
+        'eslint-comments/no-unlimited-disable': [2],
+        // Disallow unused eslint-disable comments
+        'eslint-comments/no-unused-disable'   : [2],
+    },
+};

--- a/rules/flowtype.js
+++ b/rules/flowtype.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+    'plugins': [
+        'flowtype',
+    ],
+    'extends': [
+        'plugin:flowtype/recommended',
+    ],
+    'settings': {
+        'flowtype': {
+            'onlyFilesWithFlowAnnotation': true,
+        },
+    },
+    'rules': {
+        // Force comma dangle for multiline types
+        'flowtype/delimiter-dangle'              : [2, 'always-multiline'],
+        // Force comma delimeters in objects, not semicolons
+        'flowtype/object-type-delimiter'         : [2, 'comma'],
+        // Require all files to have a block-style flow annotation
+        'flowtype/require-valid-file-annotation' : [2, 'always', {'annotationStyle': 'block'}],
+        // Enforce semicolons after type definitions
+        'flowtype/semi'                          : [2, 'always'],
+        // Prevent duplicate keys in type aliases (mirrors ESLint `no-dupe-keys`)
+        'flowtype/no-dupe-keys'                  : [2],
+        // Prevent accidental use of primitive types like "Boolean"
+        'flowtype/no-primitive-constructor-types': [2],
+    },
+};

--- a/rules/react.js
+++ b/rules/react.js
@@ -22,12 +22,8 @@ module.exports = {
         'react/jsx-equals-spacing'          : [2],
         // Ensure correct position of the first property
         'react/jsx-first-prop-new-line'     : [2, 'multiline'],
-        // Enforce handler naming convention
-        'react/jsx-handler-names'           : [2],
         // Validate props indentation in JSX
         'react/jsx-indent-props'            : [2, 4],
-        // Validate JSX indentation
-        'react/jsx-indent'                  : [2, 4],
         // Detect missing key prop
         'react/jsx-key'                     : [2],
         // Limit maximum of props on a single line in JSX
@@ -42,8 +38,6 @@ module.exports = {
         'react/jsx-no-undef'                : [2],
         // Enforce PascalCase for user-defined JSX components
         'react/jsx-pascal-case'             : [2],
-        // Enforce props alphabetical sorting
-        'react/jsx-sort-props'              : [2, {'callbacksLast': true, 'ignoreCase': true, 'shorthandFirst': true}],
         // Validate whitespace in and around the JSX opening and closing brackets
         'react/jsx-tag-spacing'             : [2],
         // Prevent React to be incorrectly marked as unused
@@ -72,8 +66,6 @@ module.exports = {
         'react/no-find-dom-node'            : [2],
         // Prevent usage of isMounted
         'react/no-is-mounted'               : [2],
-        //
-        'react/no-multi-comp'               : [2],
         // Prevent usage of the return value of React.render
         'react/no-render-return-value'      : [2],
         // Prevent using string references
@@ -88,8 +80,6 @@ module.exports = {
         'react/prop-types'                  : [2],
         // Prevent missing React when using JSX
         'react/react-in-jsx-scope'          : [2],
-        // Enforce a defaultProps definition for every prop that is not a required prop
-        'react/require-default-props'       : [2],
         // Enforce ES5 or ES6 class for returning value in render function
         'react/require-render-return'       : [2],
         // Prevent extra closing tags for components without children
@@ -100,11 +90,16 @@ module.exports = {
         'react/display-name'                : [0],
         'react/forbid-component-props'      : [0],
         'react/jsx-filename-extension'      : [0],
+        'react/jsx-handler-names'           : [0],
+        'react/jsx-indent'                  : [0], // ESLint itself does a good job now
         'react/jsx-no-bind'                 : [0],
         'react/jsx-no-literals'             : [0],
+        'react/jsx-no-multi-comp'           : [0],
         'react/jsx-no-set-state'            : [0],
+        'react/jsx-sort-props'              : [0],
         'react/no-unused-prop-types'        : [0], // Waiting for the problems mentioned in https://github.com/yannickcr/eslint-plugin-react/issues/976#issuecomment-268995092 to be addressed
         'react/prefer-stateless-function'   : [0],
+        'react/require-default-props'       : [0],
         'react/require-optimization'        : [0],
         'react/sort-comp'                   : [0], // Would like to enable, but is a big job
         'react/sort-prop-types'             : [0],

--- a/rules/react.js
+++ b/rules/react.js
@@ -70,10 +70,16 @@ module.exports = {
         'react/no-render-return-value'      : [2],
         // Prevent using string references
         'react/no-string-refs'              : [2],
+        // Prevent casing typos in react class and lifecycle methods
+        'react/no-typos'                    : [2],
         // Prevent invalid characters from appearing in markup
         'react/no-unescaped-entities'       : [2],
         // Prevent usage of unknown DOM property
         'react/no-unknown-property'         : [2],
+        // Prevent unused props
+        'react/no-unused-prop-types'        : [2],
+        // Prevent unused state
+        'react/no-unused-state'             : [2],
         // Prefer es6 class instead of createClass for React Components
         'react/prefer-es6-class'            : [2],
         // Prevent missing props validation in a React component definition
@@ -97,7 +103,6 @@ module.exports = {
         'react/jsx-no-multi-comp'           : [0],
         'react/jsx-no-set-state'            : [0],
         'react/jsx-sort-props'              : [0],
-        'react/no-unused-prop-types'        : [0], // Waiting for the problems mentioned in https://github.com/yannickcr/eslint-plugin-react/issues/976#issuecomment-268995092 to be addressed
         'react/prefer-stateless-function'   : [0],
         'react/require-default-props'       : [0],
         'react/require-optimization'        : [0],

--- a/rules/react.js
+++ b/rules/react.js
@@ -46,6 +46,8 @@ module.exports = {
         'react/jsx-uses-vars'               : [2],
         // Prevent missing parentheses around multilines JSX
         'react/jsx-wrap-multilines'         : [2],
+        // Avoid possible state update batching problems
+        'react/no-access-state-in-setstate' : [2],
         // Prevent usage of Array index in keys
         'react/no-array-index-key'          : [2],
         // Prevent passing of children as props

--- a/rules/style.js
+++ b/rules/style.js
@@ -23,7 +23,7 @@ module.exports = {
         // Disallow spacing between function identifiers and their invocations
         'func-call-spacing'            : [2],
         // Enforce four space indent width for your code
-        'indent'                       : [2, 4],
+        'indent'                       : [2, 4, {'SwitchCase': 1}],
         // Enforce spacing between keys and values in object literal properties
         'key-spacing'                  : [2, {'beforeColon': false, 'afterColon': true}],
         // Enforce spacing around keywords

--- a/rules/style.js
+++ b/rules/style.js
@@ -8,8 +8,6 @@ module.exports = {
         'block-spacing'                : [2, 'always'],
         // Enforce one true brace style
         'brace-style'                  : [2, '1tbs', {'allowSingleLine': true}],
-        // Enforce capitalization of the first letter of a comment
-        'capitalized-comments'         : [2, 'always', {'ignoreConsecutiveComments': true}],
         // Enforce trailing commas in multiline object literals
         'comma-dangle'                 : [2, 'always-multiline'],
         // Enforce spacing after comma
@@ -82,5 +80,7 @@ module.exports = {
         'space-unary-ops'              : [2],
         // Enforce consistent spacing after the // or /* in a comment
         'spaced-comment'               : [2, 'always', {'block': {'exceptions': ['-'], 'balanced': true}}],
+        // --- Disabled Rules ---
+        'capitalized-comments'         : [0],
     },
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -28,6 +28,8 @@ module.exports = {
         'keyword-spacing'              : [2],
         // Disallow mixed 'LF' and 'CRLF' as linebreaks
         'linebreak-style'              : [2, 'unix'],
+        // Enforce a line between class memebers
+        'lines-between-class-members'  : [2, 'always', {'exceptAfterSingleLine': true}],
         // Enforce a maximum number of statements allowed per line
         'max-statements-per-line'      : [2, {'max': 1}],
         // Require an empty line before return statements

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,8 +325,8 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-"eslint-config-nutshell@file:.":
-  version "6.0.1"
+"eslint-config-nutshell@file:./.":
+  version "7.0.0"
 
 eslint-find-rules@^3.1.1:
   version "3.1.1"
@@ -356,6 +356,12 @@ eslint-module-utils@^2.1.1:
 eslint-plugin-babel@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
+
+eslint-plugin-flowtype@^2.42.0:
+  version "2.42.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.42.0.tgz#7fcc98df4ed9482a22ac10ba4ca48d649c4c733a"
+  dependencies:
+    lodash "^4.15.0"
 
 eslint-plugin-import@^2.7.0:
   version "2.7.0"
@@ -804,7 +810,7 @@ lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.3.tgz#557ed7d2a9438cac5fd5a43043ca60cb455e01f7"
 
-lodash@^4.17.4:
+lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,13 +378,14 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-react@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz#27770acf39f5fd49cd0af4083ce58104eb390d4c"
+eslint-plugin-react@^7.6.1:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz#5d0e908be599f0c02fbf4eef0c7ed6f29dff7633"
   dependencies:
-    doctrine "^2.0.0"
+    doctrine "^2.0.2"
     has "^1.0.1"
-    jsx-ast-utils "^1.4.1"
+    jsx-ast-utils "^2.0.1"
+    prop-types "^15.6.0"
 
 eslint-rule-documentation@^1.0.0:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,13 @@ eslint-plugin-babel@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
 
+eslint-plugin-eslint-comments@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-2.0.2.tgz#006e1c834beffe6ff3014e84a3ae69acfa539a28"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^3.3.7"
+
 eslint-plugin-flowtype@^2.42.0:
   version "2.42.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.42.0.tgz#7fcc98df4ed9482a22ac10ba4ca48d649c4c733a"
@@ -722,6 +729,10 @@ iconv-lite@~0.4.13:
 ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
+
+ignore@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 imurmurhash@^0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -77,6 +84,10 @@ array-uniq@^1.0.1:
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -253,6 +264,10 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -289,6 +304,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
 del@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
@@ -315,11 +337,41 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+doctrine@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 error-ex@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.0.tgz#e67b43f3e82c96ea3a584ffee0b9fc3325d802d9"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.7.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -503,6 +555,18 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -538,6 +602,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -545,6 +613,10 @@ fs.realpath@^1.0.0:
 function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -627,6 +699,10 @@ iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
+iconv-lite@~0.4.13:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
 ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
@@ -685,6 +761,14 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -715,15 +799,25 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -736,6 +830,13 @@ isexe@^1.1.1:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 js-tokens@^2.0.0:
   version "2.0.0"
@@ -770,9 +871,11 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsx-ast-utils@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+jsx-ast-utils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
+  dependencies:
+    array-includes "^3.0.3"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -820,6 +923,12 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
   dependencies:
     js-tokens "^2.0.0"
+
+loose-envify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -876,6 +985,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 normalize-package-data@^2.3.2:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.5.tgz#8d924f142960e1777e7ffe170543631cc7cb02df"
@@ -898,6 +1014,14 @@ number-is-nan@^1.0.0:
 object-assign@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
+object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 once@^1.3.0:
   version "1.4.0"
@@ -1026,6 +1150,20 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -1126,6 +1264,10 @@ semver@^5.3.0:
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -1266,6 +1408,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+ua-parser-js@^0.7.9:
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -1276,6 +1422,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,9 +12,9 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
+acorn@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
 
 ajv-keywords@^1.0.0:
   version "1.5.0"
@@ -27,14 +27,14 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
-    json-stable-stringify "^1.0.1"
 
 ansi-escapes@^2.0.0:
   version "2.0.0"
@@ -190,7 +190,7 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.0, chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -203,6 +203,14 @@ chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
 chalk@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -296,6 +304,12 @@ debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -330,14 +344,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
-  dependencies:
-    esutils "^2.0.2"
-    isarray "^1.0.0"
-
-doctrine@^2.0.2:
+doctrine@^2.0.2, doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -450,32 +457,36 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.3.0.tgz#fcd7c96376bbf34c85ee67ed0012a299642b108f"
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^4.7.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.16.0.tgz#934ada9e98715e1d7bbfd6f6f0519ed2fab35cc1"
   dependencies:
-    ajv "^5.2.0"
+    ajv "^5.3.0"
     babel-code-frame "^6.22.0"
-    chalk "^1.1.3"
+    chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^2.6.8"
-    doctrine "^2.0.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
-    espree "^3.4.3"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
     esquery "^1.0.0"
-    estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
-    globals "^9.17.0"
+    globals "^11.0.1"
     ignore "^3.3.3"
     imurmurhash "^0.1.4"
     inquirer "^3.0.6"
     is-resolvable "^1.0.0"
-    js-yaml "^3.8.4"
-    json-stable-stringify "^1.0.1"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.4"
     minimatch "^3.0.2"
@@ -483,19 +494,20 @@ eslint@^4.3.0:
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^4.0.0"
+    pluralize "^7.0.0"
     progress "^2.0.0"
     require-uncached "^1.0.3"
     semver "^5.3.0"
+    strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
+espree@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
-    acorn "^5.0.1"
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@^4.0.0:
@@ -515,7 +527,7 @@ esrecurse@^4.1.0:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -550,6 +562,10 @@ external-editor@^2.0.4:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -652,13 +668,13 @@ glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+globals@^11.0.1:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+
 globals@^9.0.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
-
-globals@^9.17.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -846,9 +862,9 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.8.4:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+js-yaml@^3.9.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -860,6 +876,10 @@ jschardet@^1.4.2:
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -1134,9 +1154,9 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pluralize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This commit does a few things:

- Standardizes linting rules that were already being applied across Nutshell projects
- Removes the much-maligned capitalized-comments rule
- Adds a few new react rules, particularly unused props and state
- Adds a few dumb styling rules like semicolons after class properties and spaces between multiline class members (which also bumps the minimum ESLint version somewhat)
- Adds `eslint-plugin-eslint-comments` to catch bad eslint disabling comments
